### PR TITLE
specify exact jfryman-nginx puppet module version to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ to date as I change things / add features.
 
  * Install puppet and puppetmaster (they can be on the same
    server). 3.4.x+ is required.
- * `puppet module install jfryman-nginx`
+ * `puppet module install jfryman-nginx -v 0.0.10` (must install v0.0.10, [see here](https://github.com/jfryman/puppet-nginx/issues/460))
  * `puppet module install camptocamp-postfix`
  * Set up hiera:
   * add a [hiera.yaml](https://github.com/nathanielksmith/puppet-tilde/tree/master/examples/hiera.yaml) to `/etc/puppet/`


### PR DESCRIPTION
This fixes an issue with using the latest version of the jfryman-nginx puppet module.

A little under a month ago, development work on the jfryman-nginx puppet module led to an issue where config parameters weren't getting passed into the base nginx config (see https://github.com/jfryman/puppet-nginx/issues/460); this fixes that by using jfryman's recommended solution, specifying the exact version (0.0.10) to use for now.
