### PR TITLE
replace ngircd with charybdis

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ to date as I change things / add features.
 
  * Install puppet and puppetmaster (they can be on the same
    server). 3.4.x+ is required.
+ * `puppet module install hunner-charybdis` *on the puppetmaster*
  * `puppet module install jfryman-nginx`
  * `puppet module install camptocamp-postfix`
  * Set up hiera:
@@ -21,9 +22,9 @@ to date as I change things / add features.
   * `ln -s /etc/puppet/hiera.yaml /etc/hiera.yaml`
   * `mkdir /etc/puppet/hieradata`
   * add and **configure** [common.yaml](https://github.com/nathanielksmith/puppet-tilde/tree/master/examples/common.yaml) to `/etc/puppet/hieradata/`
+  * also add and **configure** [common.yaml](https://github.com/nathanielksmith/puppet-tilde/tree/master/examples/common.yaml) to `/etc/puppet/hierdata/node/[yourhostfqdn].yaml`
  * `cd /etc/puppet/modules`
  * `git clone https://github.com/nathanielksmith/puppet-tilde.git tilde`
- * `git clone https://github.com/nathanielksmith/puppet-ngircd ngircd`
  * edit [site.pp](https://github.com/nathanielksmith/puppet-tilde/tree/master/examples/site.pp) and save to `/etc/puppet/manifests/site.pp`
  * `puppet agent -t`
 
@@ -70,16 +71,12 @@ or _tilde.farm_ or _drawbridge.club_) and sets up an nginx vhost with:
 
 ## IRC
 
-The module sets up ngircd for you.
+The module sets up the charybdis IRC server for you.
 
- * localhost only
  * "irc" alias added to users' .bashrc
- * per-user irssi config this will auto-connect to the
-   server and auto-join #<hostname> where hostname is a .-less string
-   substitution of the hostname you specified as `tilde::hostname`.
+ * per-user irssi config this will auto-connect to the server and auto-join #<hostname> where hostname is a .-less string substitution of the hostname you specified as `tilde::hostname`.
 
-It does **not** set up an operator. IRC governance is up to the
-autonomous collective to determine.
+Your localhost root user will have OPER privileges in IRC, using the password you configured in your `[yourhostfqdn].yaml` or `common.yaml` file.
 
 ## Mail
 
@@ -151,6 +148,7 @@ or configure common.yaml with
 
  * Nathaniel Smith <nks@lambdaphil.es>
  * Chris Roddy <cmr@mdc2.org>
+ * Jason Levine <jason@queso.com>
 
 ## License
 

--- a/examples/common.yaml
+++ b/examples/common.yaml
@@ -1,5 +1,8 @@
-# REQUIRED. This sets up the webserver.
-tilde::hostname: tilde.town
+# REQUIRED. This is used to set up a few of the servers (web, IRC, NNTP).
+tilde::hostname: your.new.fqdn
+
+# REQUIRED. This is used in the IRC server setup.
+tilde::irc::rootoperpass: example
 
 # OPTIONAL. This allows you to customize the package listing for your
 # server. The default packages are in manifests/packages.pp.

--- a/examples/hiera.yaml
+++ b/examples/hiera.yaml
@@ -1,6 +1,7 @@
 # You should be able to copy this wholesale. Just don't forget to
 # mkdir /etc/puppet/hieradata.
 :hierarchy:
+  - "node/%{::fqdn}"
   - common
 
 :backends:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,7 +3,10 @@ class tilde ($use_quota = true, $addtl_packages = [], $users, $hostname) {
   include tilde::packages
   include tilde::mail
   include tilde::skel
-  include tilde::irc
+	
+	class {'tilde::irc':
+		hostname => $hostname
+	}
 
   class {'tilde::nntp':
     hostname => $hostname,

--- a/manifests/irc.pp
+++ b/manifests/irc.pp
@@ -1,13 +1,84 @@
-class tilde::irc {
+class tilde::irc ($hostname, $rootoperpass) inherits charybdis {
 
+  # substituted in in the irssi default config file for users
   $channel = regsubst($tilde::hostname, '\.', '')
 
-  class { 'ngircd':
-    server_name => 'localhost',
-    dns => 'no',
+  class { 'charybdis::serverinfo':
+    server_name => "${hostname}",
+    server_id => '99Z',
+    server_description => 'tilde charybdis server',
+    network_name => 'tilde.club',
+    network_description => 'your very own network!',
+    hub => true,
+    ssl_cert => '/etc/charybdis/test.cert',
+    ssl_private_key => '/etc/charybdis/test.key',
+    ssl_dh_params => '/etc/charybdis/dh.pem',
+    ssld_count => '1',
+    max_clients => '1024',
+    restartpass => "notused",
+    diepass => "notused"
+  }
+  class { 'charybdis::admin':
+    adminname => 'Tilde Node Administrator',
+    description => 'node IRC administrator',
+    email => 'admin@node'
+  }
+  charybdis::listen { 'default':
+    port => '6665 .. 6669',
+    sslport => '6697'
+  }
+  charybdis::operator { 'root':
+    users => [ 'root@127.0.0.0/8' ],
+    privset => 'admin',
+    password => "${rootoperpass}",
+    snomask => '+Zbfkrsuy',
+    flags => [ '~encrypted' ]
+  }
+  class { 'charybdis::cluster':
+    clustername => '*.tilde.club'
   }
 
-  ngircd::server { 'internal':
-    host => 'localhost',
+  # set up our auth sections
+  charybdis::auth { 'localhostusers':
+    order => '2',
+    users => '*@127.0.0.0/8',
+    authclass => 'users'
   }
+
+  include charybdis::log
+  include charybdis::default::alias
+  include charybdis::default::channel
+  include charybdis::default::general
+  include charybdis::default::modules
+  include charybdis::default::privset
+  include charybdis::default::serverhide
+
+  # set up our user classes
+  charybdis::class { 'users':
+    ping_time => '2 minutes',
+    number_per_ident => '10',
+    number_per_ip => '1024',
+    number_per_ip_global => '1024',
+    cidr_ipv4_bitlen => '24',
+    cidr_ipv6_bitlen => '64',
+    number_per_cidr => '1024',
+    max_number => '3000',
+    sendq => '400 kbytes'
+  }
+  charybdis::class { 'opers':
+    ping_time => '5 minutes',
+    number_per_ip => '256',
+    max_number => '1024',
+    sendq => '1 megabyte'
+  }
+  charybdis::class { 'server':
+    ping_time => '5 minutes',
+    connectfreq => '5 minutes',
+    max_number => '24',
+    sendq => '4 megabytes'
+  }
+
+  charybdis::exempt { 'default': }
+  charybdis::shared { 'default': }
+
 }


### PR DESCRIPTION
Addresses issue #8, replacing `ngircd` with `charybdis`.
