### PR TITLE
reference hostname fact by instance variable

### DIFF
--- a/templates/motd.erb
+++ b/templates/motd.erb
@@ -1,11 +1,11 @@
-< welcome to <%= hostname %> >
+< welcome to <%= @hostname %> >
         \   ^__^
          \  (oo)\_______
             (__)\       )\/\
                 ||----w |
                 ||     ||
 
- * <%= hostname %> is part of the tilde network.
+ * <%= @hostname %> is part of the tilde network.
  * type 'irc' to join an internal-only IRC server/channel.
  * type alpine to check and send local mail to other users.
  * edit your public_html/index.html to do beautiful things.


### PR DESCRIPTION
the current version is deprecated and will break in puppet 4

this will silence the template warnings that are being printed on every catalog run
