### PR TITLE
Keep news articles forever by default

### DIFF
--- a/files/expire.ctl
+++ b/files/expire.ctl
@@ -1,0 +1,31 @@
+##  Configuration file for article expiration.
+##
+##  Format:
+##      /remember/:<keep>
+##      <wildmat>:<flag>:<min>:<default>:<max>
+##
+##  First line gives history retention; second line specifies expiration for
+##  group (if groupbaseexpiry is true in inn.conf).
+##      <class>         Class specified in storage.conf.
+##      <wildmat>       Wildmat-style patterns for the newsgroups.
+##      <flag>          Status of the newsgroups.
+##      <keep>          Number of days to retain a message-ID in history.
+##      <min>           Minimum number of days to keep the article.
+##      <default>       Default number of days to keep the article.
+##      <max>           Flush the article after this many days.
+##  <keep>, <min>, <default> and <max> can be floating-point numbers or the
+##  word "never".  Times are based on the arrival time for expire and expireover
+##  (unless -p is used; see expire(8) and expireover(8)), and on the posting
+##  time for history retention.
+##
+##  See the expire.ctl man page for more information.
+
+##  When an article is rejected or expires before 10 days, we still remember
+##  it for 11 days from its original posting time in case we get offered it
+##  again.  See the artcutoff parameter in inn.conf; it should match this
+##  parameter (/remember/ uses 11 days instead of 10 in order to take into
+##  account articles whose posting date is one day into the future).
+/remember/:11
+
+#  Keep forever, unless Expires: header says otherwise.
+*:A:1:never:never

--- a/manifests/nntp.pp
+++ b/manifests/nntp.pp
@@ -38,6 +38,12 @@ class tilde::nntp ($hostname, $newsgroups = [], $peers = []) {
     content => $hostname,
   }
 
+  file { '/etc/news/expire.ctl':
+    ensure => file,
+    require => Package['inn2'],
+    source => "puppet:///modules/${module_name}/expire.ctl",
+  }
+
   service { 'inn2':
     ensure => running,
     status => '/usr/sbin/innstat | /bin/grep "Server running"',


### PR DESCRIPTION
The tilde.town usenet currently shows 0 articles in all groups because they expire by default after 15 days. I think tilde NNTP can be more viable if there is visibility of past articles. There are few enough posts that it should be okay to store them indefinitely.

This patch puts /etc/news/expire.ctl under management of Puppet and updates it to not expire articles by default. I have not tested this.

Config reference: http://www.eyrie.org/~eagle/software/inn/docs-2.5/expire.ctl.html
